### PR TITLE
Use IPv4 to talk to www.tumblr.com

### DIFF
--- a/tumblr_gdpr/init.php
+++ b/tumblr_gdpr/init.php
@@ -52,6 +52,7 @@ class Tumblr_Gdpr extends Plugin {
 			"gdpr_is_acceptable_age" => "False",
 			"redirect_to" => $url);
 
+		curl_setopt($curl_handle, CURLOPT_IPRESOLVE,  CURL_IPRESOLVE_V4);
 		curl_setopt($curl_handle, CURLOPT_URL, "https://www.tumblr.com/svc/privacy/consent");
 		curl_setopt($curl_handle, CURLOPT_POST, true);
 		curl_setopt($curl_handle, CURLOPT_POSTFIELDS, http_build_query($data));


### PR DESCRIPTION
The privacy consent form doesn't actually do anything if it thinks it's being accessed from outside the EU. This is a problem if you have an IPv6 tunnel which terminates outside of the EU, because while individual Tumblr blog pages are only served over IPv4, www.tumblr.com itself also listens to IPv6.

Make cURL only use IPv4 in its call to get the cookie, to make sure we use the same routing path to www.tumblr.com as we do to the individual blog page.